### PR TITLE
fix: include tests directory in TypeScript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,6 @@
     "strictNullChecks": true,
     "alwaysStrict": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Fixes #53

The tests directory was excluded from TypeScript compilation in tsconfig.json, causing `bun run test` to fail when vitest tried to compile TypeScript test files.

Changes:
- Added `tests/**/*` to the `include` array in tsconfig.json
- Removed `tests` from the `exclude` array

Generated with [Claude Code](https://claude.ai/code)