### PR TITLE
Add Docker workflow for Go agent

### DIFF
--- a/.github/workflows/docker-go-agent.yml
+++ b/.github/workflows/docker-go-agent.yml
@@ -1,0 +1,57 @@
+name: Docker Build and Push (Go Agent)
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'go-impl/**'
+      - '.github/workflows/docker-go-agent.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'go-impl/**'
+      - '.github/workflows/docker-go-agent.yml'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/takutakahashi/slack-agent-go
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./go-impl
+          file: ./go-impl/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/go-impl/Dockerfile
+++ b/go-impl/Dockerfile
@@ -1,0 +1,45 @@
+# Build stage
+FROM golang:1.23-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git make
+
+# Set working directory
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN make build
+
+# Final stage
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates
+
+# Create non-root user
+RUN adduser -D -u 1000 appuser
+
+# Set working directory
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /app/build/slack-agent /usr/local/bin/slack-agent
+
+# Change to non-root user
+USER appuser
+
+# Expose port (if using Web API mode)
+EXPOSE 3000
+
+# Run the application
+ENTRYPOINT ["slack-agent"]
+CMD ["start"]


### PR DESCRIPTION
## Summary

- Add dedicated GitHub Actions workflow for building and pushing Go agent container image
- Create optimized Dockerfile for Go agent with multi-stage build
- Configure automatic builds on go-impl changes and publishing to ghcr.io

## Changes

- `.github/workflows/docker-go-agent.yml`: New workflow for Go agent container builds
- `go-impl/Dockerfile`: Multi-stage Dockerfile for efficient Go binary builds

## Test plan

- [x] Workflow triggers on go-impl directory changes
- [x] Builds only push to registry on main branch (not on PRs)
- [x] Uses GitHub Container Registry (ghcr.io)
- [ ] Verify workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.ai/code)